### PR TITLE
fix previewing pages show incorrect version and add code to remove other CD field prefixes.

### DIFF
--- a/decoupled-site/frontend/src/App.tsx
+++ b/decoupled-site/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import ArtistContainerPage from './pages/ArtistContainerPage';
 import ArtistDetailsPage from './pages/ArtistDetailsPage';
 import authService from './authService';
 import { useState } from 'react';
-import { isEditMode } from './helpers/urlHelper'
+import { isEditOrPreviewMode } from './helpers/urlHelper'
 import './App.css';
 import Footer from './components/Footer';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -25,7 +25,7 @@ const App = () => {
     let variables: any
     let headers = {}
     let url = singleKeyUrl
-    const modeEdit = isEditMode()
+    const modeEdit = isEditOrPreviewMode()
 
     const { mutate } = useMutation((obj: any) => obj, {
         onSuccess: (message: ContentSavedMessage) => {

--- a/decoupled-site/frontend/src/helpers/queryCacheHelper.ts
+++ b/decoupled-site/frontend/src/helpers/queryCacheHelper.ts
@@ -1,12 +1,12 @@
 import { QueryClient } from "@tanstack/react-query";
 import { Locales, StartQuery } from "../generated";
 import { ContentSavedMessage } from "../models/ContentSavedMessage";
-import { extractParams, isEditMode } from "./urlHelper";
+import { extractParams, isEditOrPreviewMode } from "./urlHelper";
 
 const generateGQLQueryVars = (token: string, pathname: string): any => {
     const { relativePath, locales, language, contentId, workId } = extractParams(pathname)
     let variables: any = { relativePath, locales: locales as Locales, language, statusEqual: "Published" };
-    if (isEditMode() && token) {
+    if (isEditOrPreviewMode() && token) {
         variables = workId === undefined 
                     ? { contentId, isCommonDraft: true, locales: locales as Locales, language } 
                     : { contentId, workId, locales: locales as Locales, language };
@@ -37,7 +37,10 @@ function updateStartQueryData(data: StartQuery, message: ContentSavedMessage) {
 function updateContentProperty(content: any, propName: string, propValue: any) {
     // we need remove the prefix icontent_ because some special properties like Name are returned with the prefix.
     propName = propName.toLowerCase()
-    propName = propName.startsWith("icontent_") ? propName.substring("icontent_".length) : propName
+    const prefixesToRemove = ["icontent_", "ichangetrackable_", "iversionable_", "iroutable_"]
+    prefixesToRemove.forEach(prefix => {
+        propName = propName.startsWith(prefix) ? propName.substring(prefix.length) : propName
+    })
 
     const matchedKey = Object.keys(content).find((key) => key.toLowerCase() === propName);
     if (!matchedKey) { return; }

--- a/decoupled-site/frontend/src/helpers/urlHelper.ts
+++ b/decoupled-site/frontend/src/helpers/urlHelper.ts
@@ -1,6 +1,6 @@
-const isEditMode = () => {
+const isEditOrPreviewMode = () => {
     const params = window.location.search.split(/[&?]+/);
-    return params.includes("epieditmode=true");
+    return params.includes("epieditmode=true") || params.includes("epieditmode=false");
 }
 
 const getImageUrl = (path = "") => {
@@ -47,4 +47,4 @@ const extractParams = (urlPath: string) => {
     return { relativePath, locales: language, language, contentId, workId }
 }
 
-export { isEditMode, extractParams, getImageUrl }
+export { isEditOrPreviewMode, extractParams, getImageUrl }

--- a/decoupled-site/frontend/src/index.tsx
+++ b/decoupled-site/frontend/src/index.tsx
@@ -10,14 +10,14 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LoginCallbackPage from './pages/LoginCallbackPage';
-import { isEditMode } from './helpers/urlHelper';
+import { isEditOrPreviewMode } from './helpers/urlHelper';
 
 const queryClient = new QueryClient();
 const backendUrl = process.env.REACT_APP_LOGIN_AUTHORITY as string
 
 export default function WrapApp() {
   useEffect(() => {
-    if(isEditMode()) {
+    if(isEditOrPreviewMode()) {
       const communicationScript = document.createElement('script');
       communicationScript.src = `${backendUrl}/episerver/cms/latest/clientresources/communicationinjector.js`;
       document.body.appendChild(communicationScript);


### PR DESCRIPTION
This PR does the following
- Fix previewing a page showing only the published version, instead of the current version.
- Added code to remove other ContentDeliveryApi field name prefixes: "icontent_", "ichangetrackable_", "iversionable_", "iroutable_".

To make the sample code match the article in Readme: https://dash.readme.com/project/digital-experience-platform/v1.4.0-content-graph/docs/on-page-editing-using-content-graph