### PR TITLE
Rename variable env

### DIFF
--- a/decoupled-site/README.md
+++ b/decoupled-site/README.md
@@ -18,7 +18,6 @@ This project uses:
 2. Config the Content Graph keys:   
     * ./backend/appsettings.json
     * ./frontend/.env
-    * ./frontend/codegen.yaml
 
 3. Open terminal for `./backend` and run `dotnet run`.
     * Navigate to http://localhost:8082/.

--- a/decoupled-site/frontend/.env
+++ b/decoupled-site/frontend/.env
@@ -1,5 +1,5 @@
 REACT_APP_CG_PROXY_URL=http://localhost:8082/EpiServer/ContentGraph/CGProxy/Query
-CONTENT_GRAPH_GATEWAY_URL=https://cg.optimizely.com/content/v2?experimental=true&auth=INPUT_SINGLE_KEY_HERE
+REACT_APP_CONTENT_GRAPH_GATEWAY_URL=https://cg.optimizely.com/content/v2?experimental=true&auth=INPUT_SINGLE_KEY_HERE
 
 REACT_APP_CONTENT_DELIVERY_API=http://localhost:8082
 REACT_APP_LOGIN_AUTHORITY=http://localhost:8082

--- a/decoupled-site/frontend/codegen.yaml
+++ b/decoupled-site/frontend/codegen.yaml
@@ -1,4 +1,4 @@
-schema: ${CONTENT_GRAPH_GATEWAY_URL}
+schema: ${REACT_APP_CONTENT_GRAPH_GATEWAY_URL}
 documents: './src/**/*.graphql'
 generates:
   ./src/generated.ts:

--- a/decoupled-site/frontend/src/App.tsx
+++ b/decoupled-site/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import { generateGQLQueryVars, updateStartQueryCache } from './helpers/queryCach
 import { BlockPage } from './pages/BlockPage';
 
 let previousSavedMessage: any = null;
-const singleKeyUrl = process.env.CONTENT_GRAPH_GATEWAY_URL as string
+const singleKeyUrl = process.env.REACT_APP_CONTENT_GRAPH_GATEWAY_URL as string
 const hmacKeyUrl = process.env.REACT_APP_CG_PROXY_URL as string
 
 const App = () => {


### PR DESCRIPTION
- As we are using `react-scripts` library, the variables in .env need to start with `REACT_APP_`